### PR TITLE
Update EventEmitter.h

### DIFF
--- a/include/EventEmitter.h
+++ b/include/EventEmitter.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <typeinfo>
 #include <typeindex>
+#include <string>
 
 namespace medooze 
 {
@@ -48,7 +49,7 @@ public:
 	template<typename Type>
 	void emit(Type& type) 
 	{
-		auto it = listeners.find(typeid(type));
+		auto it = listeners.find(typeid(Type).name());
 		if (it!=listeners.end())
 			static_cast<Listener<Type>*>(it->second.get())->emit(type);
 	}
@@ -56,11 +57,11 @@ public:
 	template<typename Type>
 	EventEmitter& on(const std::function<void (Type&)> &callback) 
 	{
-		listeners[typeid(Type)] = std::unique_ptr<BaseListener>(new Listener<Type>(callback));
+		listeners[typeid(Type).name()] = std::unique_ptr<BaseListener>(new Listener<Type>(callback));
 		return *this;
 	}
 private:
-	std::map<std::type_index,std::unique_ptr<BaseListener>> listeners;
+	std::map<std::string,std::unique_ptr<BaseListener>> listeners;
 };
 
 }; // namespace medooze


### PR DESCRIPTION
Using from different projects in the same xcode workspace causes typeid returns different type_info for the same type (text name of the type is the same but its type_index is different). Since name is the same, using std::string as key of listeners map fixes the issue.
One more change - I'm not sure whether this is a typo or not, but you use type (not Type) on line 52, I fixed this as well. If this is incorrect please revert.